### PR TITLE
fix iOS simulator debug issue

### DIFF
--- a/doric-iOS/Devkit/Classes/DoricWSClient.m
+++ b/doric-iOS/Devkit/Classes/DoricWSClient.m
@@ -66,7 +66,7 @@
         NSString *script = [dic valueForKey:@"script"];
         for (NSValue *value in  [[DoricContextManager instance] aliveContexts]) {
             DoricContext *context = value.nonretainedObjectValue;
-            if ([source containsString:context.source] || [context.source isEqualToString:@"__dev__"]) {
+            if ([source containsString:context.source] || [context.source isEqualToString:@"__dev__.ts"]) {
                 [context reload:script];
             }
         }

--- a/doric-js/bundle/doric-vm.js
+++ b/doric-js/bundle/doric-vm.js
@@ -2228,7 +2228,7 @@ let Panel = /** @class */ (() => {
         }
         __init__(data) {
             if (data) {
-                this.__data__ = JSON.parse(data);
+                this.__data__ = data.width ? data: JSON.parse(data);
             }
         }
         __onCreate__() {


### PR DESCRIPTION
1. 目前在iOS模拟器上调试的时候，默认会打开一个名为 __dev__ 的空白页，无法正常调试
2. 将ts页面和 iOS 中预定义的调试页面名称统一修改为 __dev__.ts后，可以成功唤起调试器，但doric_vm.js 中出现 json 解析异常，调试发现某些情况下 data 已经是合法的 js 对象，无需 parse