### PR TITLE
fix: iOS 上无法加载 Image.xcassets 中的图片

### DIFF
--- a/doric-iOS/Pod/Classes/Shader/DoricImageNode.m
+++ b/doric-iOS/Pod/Classes/Shader/DoricImageNode.m
@@ -244,7 +244,11 @@
         }
     } else if ([@"imageRes" isEqualToString:name]) {
         YYImage *image = [YYImage imageNamed:prop];
-        view.image = image;
+        if (image) {
+            view.image = image;
+        } else {
+            view.image = [UIImage imageNamed:prop];
+        }
 
         if (self.loadCallbackId.length > 0) {
             if (image) {


### PR DESCRIPTION
YYImage 不支持读取 Image.xcassets, 详见 ibireme/YYImage#2