### PR TITLE
fix: 编译警告

### DIFF
--- a/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
+++ b/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
@@ -109,7 +109,10 @@ typedef NS_ENUM(NSInteger, DoricGravity) {
 
 - (void)apply;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-noescape"
 - (void)apply:(CGSize)frameSize;
+#pragma clang diagnostic pop
 @end
 
 

--- a/doric-iOS/Pod/Classes/Util/DoricExtensions.h
+++ b/doric-iOS/Pod/Classes/Util/DoricExtensions.h
@@ -21,11 +21,11 @@
 
 
 @interface NSObject (Doric)
-- (id)apply:(id (^)(id it))block;
+- (id)apply:(id (NS_NOESCAPE ^)(id it))block;
 
-- (instancetype)also:(void (^)(id it))block;
+- (instancetype)also:(void (NS_NOESCAPE ^)(id it))block;
 
-- (void)let:(void (^)(id it))block;
+- (void)let:(void (NS_NOESCAPE ^)(id it))block;
 @end
 
 @interface NSArray <ObjectType> (Doric)

--- a/doric-iOS/Pod/Classes/Util/DoricExtensions.m
+++ b/doric-iOS/Pod/Classes/Util/DoricExtensions.m
@@ -20,16 +20,16 @@
 #import "DoricExtensions.h"
 
 @implementation NSObject (Doric)
-- (id)apply:(id (^)(id it))block {
+- (id)apply:(id (NS_NOESCAPE ^)(id it))block {
     return block(self);
 }
 
-- (instancetype)also:(void (^)(id it))block {
+- (instancetype)also:(void (NS_NOESCAPE ^)(id it))block {
     block(self);
     return self;
 }
 
-- (void)let:(void (^)(id it))block {
+- (void)let:(void (NS_NOESCAPE ^)(id it))block {
     block(self);
 }
 @end


### PR DESCRIPTION
忽略了同名方法 `- apply:`, 和解决了`NSObject (Doric)`的编译警告