### PR TITLE
修复因tableviewcell发生重用导致的圆角（Corner）效果丢失的问题

### DIFF
--- a/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
+++ b/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
 
 typedef UIEdgeInsets DoricMargin;
 typedef UIEdgeInsets DoricPadding;
@@ -121,3 +122,9 @@ typedef NS_ENUM(NSInteger, DoricGravity) {
 @interface UIView (DoricLayout)
 @property(nonatomic, strong) DoricLayout *doricLayout;
 @end
+
+@interface DoricShapeLayer : CAShapeLayer
+@property CGRect viewBounds;
+@property UIEdgeInsets corners;
+@end
+

--- a/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
+++ b/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
@@ -20,7 +20,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
-#import <QuartzCore/QuartzCore.h>
 
 typedef UIEdgeInsets DoricMargin;
 typedef UIEdgeInsets DoricPadding;
@@ -121,10 +120,5 @@ typedef NS_ENUM(NSInteger, DoricGravity) {
 
 @interface UIView (DoricLayout)
 @property(nonatomic, strong) DoricLayout *doricLayout;
-@end
-
-@interface DoricShapeLayer : CAShapeLayer
-@property CGRect viewBounds;
-@property UIEdgeInsets corners;
 @end
 


### PR DESCRIPTION
创建DoricShapeLayer继承于CAShapeLayer， 记录view的bounds和self.corners， 比较bounds和corners是否发生变更，若变更即需要重新创建view.layer.mask