### PR TITLE
refactor：tableview perform safe batch updates.

### DIFF
--- a/doric-iOS/Pod/Classes/Shader/DoricListNode.m
+++ b/doric-iOS/Pod/Classes/Shader/DoricListNode.m
@@ -125,16 +125,16 @@
     } else if ([@"onScrollEnd" isEqualToString:name]) {
         self.onScrollEndFuncId = prop;
     } else if ([@"scrolledPosition" isEqualToString:name]) {
-        NSUInteger position = [prop unsignedIntegerValue];
-        NSUInteger count = [self tableView:view numberOfRowsInSection:0];
-        if (position < count) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSUInteger position = [prop unsignedIntegerValue];
+            NSUInteger count = [self tableView:view numberOfRowsInSection:0];
+            if (position < count) {
                 [view scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:position inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
-            });
-        } else {
-            [self.doricContext.driver.registry onLog:DoricLogTypeError
-                                             message:[NSString stringWithFormat:@"scrolledPosition Error:%@", @"scrolledPosition range error"]];
-        }
+            } else {
+                [self.doricContext.driver.registry onLog:DoricLogTypeError
+                                                 message:[NSString stringWithFormat:@"scrolledPosition Error:%@", @"scrolledPosition range error"]];
+            }
+        });
     } else {
         [super blendView:view forPropName:name propValue:prop];
     }


### PR DESCRIPTION
question:

UITableView internal inconsistency: _visibleRows and _visibleCells must be of same length. _visibleRows: {0, 10}; _visibleCells.count: 20, _visibleCells: (
    "<DoricTableViewCell: 0x15aa553a0; baseClass = UITableViewCell; frame = (0 0; 414 74); autoresize = W; layer = <CALayer: 0x284c61280>>",

参考了
1. https://stackoverflow.com/questions/47244941/uitableview-internal-inconsistency-visiblerows-and-visiblecells-must-be-of-sa

2. https://github.com/xmartlabs/Eureka/pull/2195


