### PR TITLE
Fix possible errors in Swift and Objective-C mixed programming: 'Dori…

### DIFF
--- a/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
+++ b/doric-iOS/Pod/Classes/Shader/DoricLayouts.h
@@ -133,7 +133,7 @@ typedef NS_ENUM(NSInteger, DoricGravity) {
 @end
 
 
-@interface UIView (DoricLayout)
+@interface UIView (DoricLayouts)
 @property(nonatomic, strong) DoricLayout *doricLayout;
 @end
 

--- a/doric-iOS/Pod/Classes/Shader/DoricLayouts.m
+++ b/doric-iOS/Pod/Classes/Shader/DoricLayouts.m
@@ -76,7 +76,7 @@ static const void *kLayoutConfig = &kLayoutConfig;
 @implementation DoricShapeLayer
 @end
 
-@implementation UIView (DoricLayout)
+@implementation UIView (DoricLayouts)
 @dynamic doricLayout;
 
 - (void)setDoricLayout:(DoricLayout *)doricLayout {


### PR DESCRIPTION
Fix possible errors in Swift and Objective-C mixed programming: DoricLayout' has different definitions in different modules...